### PR TITLE
Add headless (no UI) mode to Assist

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ const config = {
   web3: Object, // The instantiated version of web3 that the Dapp is using
   mobileBlocked: Boolean, // Defines if the Dapp works on mobile
   minimumBalance: String, // Defines the minimum balance in Wei that a user needs to have to use the Dapp
+  headlessMode: Boolean, // Turn off all of Assist's UI, but still retain analytics collection
   messages: { // See custom transaction messages section below for more details
     txPending: Function, // Transaction is pending and awaiting confirmation
     txSent: Function, // Transaction has been sent to the network
@@ -171,7 +172,7 @@ mydecoratedContract.myMethod().call()
 
 #### Parameters
 
-`txObject` - `Object`: Transaction object (**Required**)  
+`txObject` - `Object`: Transaction object (**Required**)
 `callback` - `Function`: Optional error first style callback if you don't want to use promises
 
 #### Returns

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assist",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Blocknative Assist js library for Dapp developers",
   "main": "lib/assist.min.js",
   "scripts": {

--- a/src/__tests__/js/events.test.js
+++ b/src/__tests__/js/events.test.js
@@ -6,6 +6,7 @@
 import * as events from '../../js/helpers/events'
 import eventToUi from '../../js/views/event-to-ui'
 import * as utils from '../../js/helpers/utilities'
+import * as stateHelper from '../../js/helpers/state'
 
 // This function tries to send something to the websocket, so we mock it
 events.lib.logEvent = jest.fn()
@@ -26,6 +27,7 @@ for (const key in eventToUi) {
 
 test('Calls the correct UI handler function when an event is received from the server', () => {
   // AFAIK there are no other functions which call notification UI events
+  stateHelper.state.config = { headlessMode: false }
   let eventObj
   for (const key in uiMockFunctions) {
     for (const func of uiMockFunctions[key]) {
@@ -38,6 +40,24 @@ test('Calls the correct UI handler function when an event is received from the s
       expect(
         eventToUi[eventObj.categoryCode][eventObj.eventCode]
       ).toHaveBeenCalledTimes(1)
+    }
+  }
+})
+
+test('Does not call the UI handler when we are in headless mode', () => {
+  stateHelper.state.config = { headlessMode: true }
+  let eventObj
+  for (const key in uiMockFunctions) {
+    for (const func of uiMockFunctions[key]) {
+      eventObj = {
+        categoryCode: key,
+        eventCode: func,
+        transaction: { hash: '0x' }
+      }
+      events.handleEvent(eventObj)
+      expect(
+        eventToUi[eventObj.categoryCode][eventObj.eventCode]
+      ).toHaveBeenCalledTimes(0)
     }
   }
 })

--- a/src/__tests__/js/init.test.js
+++ b/src/__tests__/js/init.test.js
@@ -49,7 +49,7 @@ test('Fails if we try to decorate without a web3 instance', () => {
     '0x0000000000000000000000000000000000000000'
   )
   try {
-    const decoratedContract = assist.Contract(contract)
+    assist.Contract(contract)
   } catch (e) {
     expect(e.eventCode).toBe('initFail')
   }

--- a/src/js/helpers/events.js
+++ b/src/js/helpers/events.js
@@ -23,10 +23,12 @@ export function handleEvent(eventObj, clickHandlers) {
     }
   }
 
-  // Show UI
-  eventToUI[categoryCode] &&
-    eventToUI[categoryCode][eventCode] &&
-    eventToUI[categoryCode][eventCode](eventObj, clickHandlers)
+  // Show UI unless we're in headless mode
+  if (state.config && !state.config.headlessMode) {
+    eventToUI[categoryCode] &&
+      eventToUI[categoryCode][eventCode] &&
+      eventToUI[categoryCode][eventCode](eventObj, clickHandlers)
+  }
 }
 
 // Create event log to be sent to server

--- a/src/js/helpers/events.js
+++ b/src/js/helpers/events.js
@@ -33,7 +33,7 @@ export function handleEvent(eventObj, clickHandlers) {
 
 // Create event log to be sent to server
 export function createEventLog(eventObj) {
-  const { dappId, networkId } = state.config
+  const { dappId, networkId, headlessMode } = state.config
   const { userAgent, version } = state
   const newUser = getItem('_assist_newUser') === 'true'
   return JSON.stringify(
@@ -45,6 +45,7 @@ export function createEventLog(eventObj) {
         version,
         userAgent,
         newUser,
+        headlessMode,
         blockchain: {
           system: 'ethereum',
           network: networkName(networkId)

--- a/src/js/helpers/state.js
+++ b/src/js/helpers/state.js
@@ -32,7 +32,8 @@ export let state = {
   iframe: null,
   iframeDocument: null,
   iframeWindow: null,
-  connectionId: null
+  connectionId: null,
+  headlessMode: false
 }
 
 export function updateState(newState) {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -17,7 +17,7 @@ import {
 import styles from '../css/styles.css'
 
 // Library Version - if changing, also need to change in package.json
-const version = '0.2.0'
+const version = '0.2.1'
 
 function init(config) {
   updateState({ version })


### PR DESCRIPTION
- closes #6 

@aaronbarnardsound Was this how you saw headless mode being implemented? It's a very simplistic way of doing it but I'm not sure if this conflates concerns, let me know.

@cmeisl This should now send `headlessMode` over the websocket