### PR TITLE
added contractQueryFail eventCode to eventCodeToStep function to fix …

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,32 +35,16 @@ npm i bnc-assist
 
 #### Script Tag
 The library uses [semantic versioning](https://semver.org/spec/v2.0.0.html).
-The current version is 0.3.4.
-There are minified and non-minified versions.
-Put this script at the top of your `<head>`
-
-
-To integrate `assist.js` into your dapp, you'll need to do 4 things:
-
-1. Install the widget
-2. Initialize the library
-3. Call `onboard`
-4. Decorate your contracts
-
-### Install the widget
-
-Our widget is currently hosted on S3.
-The library uses [semantic versioning](https://semver.org/spec/v2.0.0.html).
-The current version 0.3.4.
+The current version is 0.3.5.
 There are minified and non-minified versions.
 Put this script at the top of your `<head>`
  
 ```html
-<script src="https://assist.blocknative.com/0-3-4/assist.js"></script>
+<script src="https://assist.blocknative.com/0-3-5/assist.js"></script>
 
 <!-- OR... -->
 
-<script src="https://assist.blocknative.com/0-3-4/assist.min.js"></script>
+<script src="https://assist.blocknative.com/0-3-5/assist.min.js"></script>
 ```
 
 ### Initialize the Library

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-assist",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Blocknative Assist js library for Dapp developers",
   "main": "lib/assist.min.js",
   "scripts": {

--- a/src/js/helpers/utilities.js
+++ b/src/js/helpers/utilities.js
@@ -144,6 +144,7 @@ export function eventCodeToStep(eventCode) {
     case 'walletEnable':
       return 3
     case 'networkFail':
+    case 'contractQueryFail':
       return 4
     case 'nsfFail':
       return 5

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -17,7 +17,7 @@ import {
 import styles from '../css/styles.css'
 
 // Library Version - if changing, also need to change in package.json
-const version = '0.3.4'
+const version = '0.3.5'
 
 function init(config) {
   updateState({ version })


### PR DESCRIPTION
Assist was throwing an error on a `contractQueryFail` event due to there not being a case in the `eventCodeToStep` function's switch statement to handle it.