### PR TITLE
removed UI for contract query fail event

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@ npm i bnc-assist
 
 #### Script Tag
 The library uses [semantic versioning](https://semver.org/spec/v2.0.0.html).
-The current version is 0.4.0.
+The current version is 0.4.1.
 There are minified and non-minified versions.
 Put this script at the top of your `<head>`
  
 ```html
-<script src="https://assist.blocknative.com/0-4-0/assist.js"></script>
+<script src="https://assist.blocknative.com/0-4-1/assist.js"></script>
 
 <!-- OR... -->
 
-<script src="https://assist.blocknative.com/0-4-0/assist.min.js"></script>
+<script src="https://assist.blocknative.com/0-4-1/assist.min.js"></script>
 ```
 
 ### Initialize the Library

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-assist",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Blocknative Assist js library for Dapp developers",
   "main": "lib/assist.min.js",
   "scripts": {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -17,7 +17,7 @@ import {
 import styles from '../css/styles.css'
 
 // Library Version - if changing, also need to change in package.json
-const version = '0.4.0'
+const version = '0.4.1'
 
 function init(config) {
   updateState({ version })

--- a/src/js/logic/contract-methods.js
+++ b/src/js/logic/contract-methods.js
@@ -2,9 +2,7 @@ import { promisify } from 'bluebird'
 import { state } from '../helpers/state'
 import { handleEvent } from '../helpers/events'
 import sendTransaction from './send-transaction'
-import { separateArgs, timeouts } from '../helpers/utilities'
-import { checkNetwork } from './user'
-import { addOnboardWarning } from '../views/dom'
+import { separateArgs } from '../helpers/utilities'
 
 export function modernMethod(method, methodABI, allArgs) {
   const { name, constant } = methodABI
@@ -50,32 +48,19 @@ export function modernMethod(method, methodABI, allArgs) {
             callback && callback(null, result)
             resolve(result)
           })
-          .catch(() => {
-            handleEvent(
-              {
-                eventCode: 'contractQueryFail',
-                categoryCode: 'activeContract',
-                contract: {
-                  methodName: name,
-                  parameters: args
-                },
-                reason: 'User is on the incorrect network'
+          .catch(error => {
+            handleEvent({
+              eventCode: 'contractQueryFail',
+              categoryCode: 'activeContract',
+              contract: {
+                methodName: name,
+                parameters: args
               },
-              {
-                onClose: () =>
-                  setTimeout(() => {
-                    const errorObj = new Error('User is on the wrong network')
-                    errorObj.eventCode = 'networkFail'
-                    reject(errorObj)
-                  }, timeouts.changeUI),
-                onClick: async () => {
-                  await checkNetwork()
-                  if (!state.correctNetwork) {
-                    addOnboardWarning('network')
-                  }
-                }
-              }
-            )
+              reason: error.msg
+            })
+
+            callback && callback(error)
+            reject(error)
           })
       }
 
@@ -87,7 +72,10 @@ export function modernMethod(method, methodABI, allArgs) {
           callback,
           method,
           { methodName: name, parameters: args }
-        ).catch(reject)
+        ).catch(error => {
+          callback && callback(error)
+          reject(error)
+        })
 
         resolve(txPromiseObj)
       }

--- a/src/js/logic/contract-methods.js
+++ b/src/js/logic/contract-methods.js
@@ -24,6 +24,7 @@ export function modernMethod(method, methodABI, allArgs) {
               onClose: () => {
                 const errorObj = new Error('User is on a mobile device')
                 errorObj.eventCode = 'mobileBlocked'
+                callback && callback(errorObj)
                 reject(errorObj)
               }
             }

--- a/src/js/views/event-to-ui.js
+++ b/src/js/views/event-to-ui.js
@@ -66,7 +66,6 @@ const eventToUI = {
     txFailed: notificationsUI
   },
   activeContract: {
-    contractQueryFail: onboardingUI,
     txAwaitingApproval: notificationsUI,
     txSent: notificationsUI,
     txPending: notificationsUI,


### PR DESCRIPTION
Initially I thought that a `contractQueryFail` event would only be called when the contract being queried is deployed on a different network to what the user i currently on. But it turns out that it can be called for other failures. Have removed the UI for this event and also now log the error msg. Also made sure that callbacks are being called on errors as well.