### PR TITLE
Filter the state object

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,11 +365,11 @@ state = {
   accessToAccounts: Boolean, // Dapp has access to accounts
   walletLoggedIn: Boolean, // User is logged in to wallet
   walletEnabled: Boolean, // User has enabled EIP 1102 compliant wallet
+  accountAddress: String, // Address of the user's selected account
   accountBalance: String, // User account balance
   minimumBalance: String, // User has the minimum balance specified in the config
-  correctNetwork: Boolean, // User is on the network specified in the config
   userCurrentNetworkId: Number, // Network id of the network the user is currently on
-  accountAddress: String, // Address of the user's selected account
+  correctNetwork: Boolean, // User is on the network specified in the config
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -358,41 +358,18 @@ da.Transaction(txObject)
 
 ```javascript
 state = {
-  version: String,
-  validApiKey: Boolean,
-  supportedNetwork: Boolean,
-  config: Object,
-  userAgent: String,
-  mobileDevice: Boolean,
-  validBrowser: Boolean,
-  legacyWeb3: Boolean,
-  modernWeb3: Boolean,
-  web3Version: String,
-  web3Instance: Object,
-  currentProvider: String,
-  web3Wallet: Boolean,
-  legacyWallet: Boolean,
-  modernWallet: Boolean,
-  accessToAccounts: Boolean,
-  walletLoggedIn: Boolean,
-  walletEnabled: Boolean,
-  walletEnableCalled: Boolean,
-  walletEnableCanceled: Boolean,
-  accountBalance: String,
-  correctNetwork: Boolean,
-  minimumBalance: String,
-  correctNetwork: Boolean,
-  userCurrentNetworkId: Number,
-  socket: Object,
-  pendingSocketConnection: Boolean,
-  socketConnection: Boolean,
-  accountAddress: String,
-  transactionQueue: Array,
-  transactionAwaitingApproval: Boolean,
-  iframe: Object,
-  iframeDocument: Object,
-  iframeWindow: Object,
-  connectionId: String
+  mobileDevice: Boolean, // User is on a mobile device
+  validBrowser: Boolean, // User is on a valid web3 browser
+  currentProvider: String, // Current provider being used to connect to the network
+  web3Wallet: Boolean, // User has a web3Wallet installed
+  accessToAccounts: Boolean, // Dapp has access to accounts
+  walletLoggedIn: Boolean, // User is logged in to wallet
+  walletEnabled: Boolean, // User has enabled EIP 1102 compliant wallet
+  accountBalance: String, // User account balance
+  minimumBalance: String, // User has the minimum balance specified in the config
+  correctNetwork: Boolean, // User is on the network specified in the config
+  userCurrentNetworkId: Number, // Network id of the network the user is currently on
+  accountAddress: String, // Address of the user's selected account
 }
 ```
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -452,7 +452,33 @@ function init(config) {
 function getState() {
   return new Promise(async (resolve, reject) => {
     await checkUserEnvironment().catch(reject)
-    resolve(state)
+    const {
+      mobileDevice,
+      validBrowser,
+      currentProvider,
+      web3Wallet,
+      accessToAccounts,
+      walletLoggedIn,
+      walletEnabled,
+      accountAddress,
+      accountBalance,
+      userCurrentNetworkId,
+      correctNetwork
+    } = state
+
+    resolve({
+      mobileDevice,
+      validBrowser,
+      currentProvider,
+      web3Wallet,
+      accessToAccounts,
+      walletLoggedIn,
+      walletEnabled,
+      accountAddress,
+      accountBalance,
+      userCurrentNetworkId,
+      correctNetwork
+    })
   })
 }
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -462,6 +462,7 @@ function getState() {
       walletEnabled,
       accountAddress,
       accountBalance,
+      minimumBalance,
       userCurrentNetworkId,
       correctNetwork
     } = state
@@ -476,6 +477,7 @@ function getState() {
       walletEnabled,
       accountAddress,
       accountBalance,
+      minimumBalance,
       userCurrentNetworkId,
       correctNetwork
     })


### PR DESCRIPTION
This PR filters the state object that is returned by the `getState` function to only the essential information needed if a dev was on-boarding a user without using the `onboard` function. 

Add any comments if you think that it is missing some properties or needs to be filtered down some more @cmeisl @morelazers 

Closes #58 