### PR TITLE
added uuid for each transaction, general refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,16 @@ yarn add bnc-assist
 #### Script Tag
 
 The library uses [semantic versioning](https://semver.org/spec/v2.0.0.html).
-The current version is 0.5.0.
+The current version is 0.5.1.
 There are minified and non-minified versions.
 Put this script at the top of your `<head>`
 
 ```html
-<script src="https://assist.blocknative.com/0-5-0/assist.js"></script>
+<script src="https://assist.blocknative.com/0-5-1/assist.js"></script>
 
 <!-- OR... -->
 
-<script src="https://assist.blocknative.com/0-5-0/assist.min.js"></script>
+<script src="https://assist.blocknative.com/0-5-1/assist.min.js"></script>
 ```
 
 ### Initialize the Library

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-assist",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Blocknative Assist js library for Dapp developers",
   "main": "lib/assist.min.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "@babel/polyfill": "^7.0.0",
     "babel-eslint": "^10.0.1",
     "bluebird": "^3.5.3",
-    "bowser": "^2.0.0-beta.3"
+    "bowser": "^2.0.0-beta.3",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",

--- a/src/js/helpers/utilities.js
+++ b/src/js/helpers/utilities.js
@@ -1,3 +1,4 @@
+import uuid from 'uuid/v4'
 import { state } from './state'
 import { handleEvent } from './events'
 
@@ -29,13 +30,12 @@ export function nowInTxPool(txHash) {
   txObj.transaction.inTxPool = true
 }
 
-export function isDuplicateTransaction(txObject) {
+export function isDuplicateTransaction({ value, to }) {
   const { transactionQueue } = state
-  return transactionQueue.filter(
-    txObj =>
-      txObj.transaction.value === txObject.value &&
-      txObj.transaction.to === txObject.to
-  )[0]
+
+  return transactionQueue.find(
+    txObj => txObj.transaction.value === value && txObj.transaction.to === to
+  )
 }
 
 // Nice time format
@@ -94,6 +94,10 @@ export function handleError(categoryCode, propagateError) {
 
     propagateError && propagateError(errorObj)
   }
+}
+
+export function createTransactionId() {
+  return uuid()
 }
 
 export function capitalize(str) {

--- a/src/js/helpers/web3.js
+++ b/src/js/helpers/web3.js
@@ -89,7 +89,9 @@ export const web3Functions = {
       default:
         return () => Promise.reject(errorObj)
     }
-  }
+  },
+  txReceipt: txHash =>
+    promisify(state.web3Instance.eth.getTransactionReceipt)(txHash)
 }
 
 export function configureWeb3(web3) {
@@ -167,10 +169,10 @@ export function getNonce(address) {
   return web3Functions.nonce(version)(address)
 }
 
-export function hasSufficientBalance(
+export function getTransactionParams(
   txObject = {},
   contractMethod,
-  methodArgs
+  contractEventObj
 ) {
   return new Promise(async (resolve, reject) => {
     const version = state.web3Version && state.web3Version.slice(0, 3)
@@ -180,7 +182,7 @@ export function hasSufficientBalance(
       txObject.value = formatNumber(txObject.value)
     }
 
-    const transactionValue = txObject.value
+    const value = txObject.value
       ? await web3Functions
           .bigNumber(version)(txObject.value)
           .catch(handleError('web3', reject))
@@ -206,7 +208,7 @@ export function hasSufficientBalance(
             await web3Functions
               .contractGas(version)(
                 contractMethod,
-                methodArgs.parameters,
+                contractEventObj.parameters,
                 txObject
               )
               .catch(handleError('web3', reject))
@@ -220,33 +222,32 @@ export function hasSufficientBalance(
           )
           .catch(handleError('web3', reject))
 
-    const transactionFee = gas.mul(gasPrice)
+    resolve({ value, gasPrice, gas })
+  })
+}
 
-    const buffer = transactionFee.div(
+export function hasSufficientBalance({ value, gas, gasPrice }) {
+  return new Promise(async (resolve, reject) => {
+    const version = state.web3Version && state.web3Version.slice(0, 3)
+
+    const gasCost = gas.mul(gasPrice)
+
+    const buffer = gasCost.div(
       await web3Functions
         .bigNumber(version)('10')
         .catch(handleError('web3', reject))
     )
 
-    const totalTransactionCost = transactionFee
-      .add(transactionValue)
-      .add(buffer)
+    const transactionCost = gasCost.add(value).add(buffer)
 
     const balance = await getAccountBalance().catch(handleError('web3', reject))
     const accountBalance = await web3Functions
       .bigNumber(version)(balance)
       .catch(handleError('web3', reject))
 
-    const sufficientBalance = accountBalance.gt(totalTransactionCost)
+    const sufficientBalance = accountBalance.gt(transactionCost)
 
-    const transactionParams = {
-      value: transactionValue.toString(),
-      gas: gas.toString(),
-      gasPrice: gasPrice.toString(),
-      to: txObject.to
-    }
-
-    resolve({ transactionParams, sufficientBalance })
+    resolve(sufficientBalance)
   })
 }
 
@@ -256,7 +257,7 @@ export function getAccountBalance() {
     updateState({ accountAddress: accounts[0] })
 
     const version = state.web3Version && state.web3Version.slice(0, 3)
-    const balance = web3Functions
+    const balance = await web3Functions
       .balance(version)(accounts[0])
       .catch(handleError('web3', reject))
 
@@ -318,19 +319,20 @@ export function getCurrentProvider() {
 
 // Poll for a tx receipt
 export function waitForTransactionReceipt(txHash) {
-  const web3 = state.web3Instance || window.web3
   return new Promise((resolve, reject) => {
+    return checkForReceipt()
+
     function checkForReceipt() {
-      web3.eth.getTransactionReceipt(txHash, (err, res) => {
-        if (err) {
-          return reject(err)
-        }
-        if (res === null) {
-          return setTimeout(() => checkForReceipt(), timeouts.pollForReceipt)
-        }
-        return resolve(res)
-      })
+      return web3Functions
+        .txReceipt(txHash)
+        .then(txReceipt => {
+          if (!txReceipt) {
+            return setTimeout(() => checkForReceipt(), timeouts.pollForReceipt)
+          }
+
+          return resolve(txReceipt)
+        })
+        .catch(reject)
     }
-    checkForReceipt()
   })
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -25,7 +25,7 @@ import {
 import styles from '../css/styles.css'
 
 // Library Version - if changing, also need to change in package.json
-const version = '0.5.0'
+const version = '0.5.1'
 
 function init(config) {
   updateState({ version })

--- a/src/js/logic/send-transaction.js
+++ b/src/js/logic/send-transaction.js
@@ -4,7 +4,8 @@ import { prepareForTransaction } from './user'
 import {
   hasSufficientBalance,
   getNonce,
-  waitForTransactionReceipt
+  waitForTransactionReceipt,
+  getTransactionParams
 } from '../helpers/web3'
 import {
   isDuplicateTransaction,
@@ -14,7 +15,8 @@ import {
   addTransactionToQueue,
   timeouts,
   extractMessageFromError,
-  handleError
+  handleError,
+  createTransactionId
 } from '../helpers/utilities'
 
 function inferNonce() {
@@ -37,31 +39,40 @@ function sendTransaction(
   contractEventObj
 ) {
   return new Promise(async (resolve, reject) => {
-    // Prepare for transaction
-    try {
-      await prepareForTransaction('activePreflight')
-    } catch (errorObj) {
-      reject(errorObj)
-      return
-    }
+    // Make sure user is onboarded and ready to transact
+    await prepareForTransaction('activePreflight').catch(reject)
 
     // make sure that we have from address in txObject
     if (!txObject.from) {
       txObject.from = state.accountAddress
     }
 
-    // Get the total transaction cost and see if there is enough balance
-    const { sufficientBalance, transactionParams } = await hasSufficientBalance(
+    const transactionId = createTransactionId()
+
+    const transactionParams = await getTransactionParams(
       txObject,
       contractMethod,
       contractEventObj
+    ).catch(reject)
+
+    const transactionEventObj = {
+      id: transactionId,
+      gas: transactionParams.gas.toString(),
+      gasPrice: transactionParams.gasPrice.toString(),
+      value: transactionParams.value.toString(),
+      to: txObject.to,
+      from: txObject.from
+    }
+
+    const sufficientBalance = await hasSufficientBalance(
+      transactionParams
     ).catch(reject)
 
     if (!sufficientBalance) {
       handleEvent({
         eventCode: 'nsfFail',
         categoryCode: 'activePreflight',
-        transaction: transactionParams,
+        transaction: transactionEventObj,
         wallet: {
           provider: state.currentProvider,
           address: state.accountAddress,
@@ -77,43 +88,36 @@ function sendTransaction(
       return
     }
 
-    const duplicateTransaction = isDuplicateTransaction(transactionParams)
+    const duplicateTransaction = isDuplicateTransaction(transactionEventObj)
+
     if (duplicateTransaction) {
-      handleEvent(
-        addContractEventObj(
-          {
-            eventCode: 'txRepeat',
-            categoryCode: 'activePreflight',
-            transaction: transactionParams,
-            wallet: {
-              provider: state.currentProvider,
-              address: state.accountAddress,
-              balance: state.accountBalance,
-              minimum: state.config.minimumBalance
-            }
-          },
-          contractEventObj
-        )
-      )
+      handleEvent({
+        eventCode: 'txRepeat',
+        categoryCode: 'activePreflight',
+        transaction: transactionEventObj,
+        contract: contractEventObj,
+        wallet: {
+          provider: state.currentProvider,
+          address: state.accountAddress,
+          balance: state.accountBalance,
+          minimum: state.config.minimumBalance
+        }
+      })
     }
 
     if (state.transactionAwaitingApproval) {
-      handleEvent(
-        addContractEventObj(
-          {
-            eventCode: 'txAwaitingApproval',
-            categoryCode: 'activePreflight',
-            transaction: transactionParams,
-            wallet: {
-              provider: state.currentProvider,
-              address: state.accountAddress,
-              balance: state.accountBalance,
-              minimum: state.config.minimumBalance
-            }
-          },
-          contractEventObj
-        )
-      )
+      handleEvent({
+        eventCode: 'txAwaitingApproval',
+        categoryCode: 'activePreflight',
+        transaction: transactionEventObj,
+        contract: contractEventObj,
+        wallet: {
+          provider: state.currentProvider,
+          address: state.accountAddress,
+          balance: state.accountBalance,
+          minimum: state.config.minimumBalance
+        }
+      })
     }
 
     let txPromise
@@ -133,22 +137,18 @@ function sendTransaction(
 
     resolve(txPromise)
 
-    handleEvent(
-      addContractEventObj(
-        {
-          eventCode: 'txRequest',
-          categoryCode,
-          transaction: transactionParams,
-          wallet: {
-            provider: state.currentProvider,
-            address: state.accountAddress,
-            balance: state.accountBalance,
-            minimum: state.config.minimumBalance
-          }
-        },
-        contractEventObj
-      )
-    )
+    handleEvent({
+      eventCode: 'txRequest',
+      categoryCode,
+      transaction: transactionEventObj,
+      contract: contractEventObj,
+      wallet: {
+        provider: state.currentProvider,
+        address: state.accountAddress,
+        balance: state.accountBalance,
+        minimum: state.config.minimumBalance
+      }
+    })
 
     updateState({ transactionAwaitingApproval: true })
 
@@ -158,41 +158,40 @@ function sendTransaction(
     // Check if user has confirmed transaction after 20 seconds
     setTimeout(async () => {
       const nonce = await inferNonce().catch(reject)
+
       if (!checkTransactionQueue(nonce) && !rejected && !confirmed) {
-        handleEvent(
-          addContractEventObj(
-            {
-              eventCode: 'txConfirmReminder',
-              categoryCode,
-              transaction: transactionParams,
-              wallet: {
-                provider: state.currentProvider,
-                address: state.accountAddress,
-                balance: state.accountBalance,
-                minimum: state.config.minimumBalance
-              }
-            },
-            contractEventObj
-          )
-        )
+        handleEvent({
+          eventCode: 'txConfirmReminder',
+          categoryCode,
+          transaction: transactionEventObj,
+          contract: contractEventObj,
+          wallet: {
+            provider: state.currentProvider,
+            address: state.accountAddress,
+            balance: state.accountBalance,
+            minimum: state.config.minimumBalance
+          }
+        })
       }
     }, timeouts.txConfirmReminder)
 
     if (state.legacyWeb3) {
       txPromise
-        .then(async txHash => {
-          confirmed = handleTxHash(
+        .then(txHash => {
+          confirmed = true
+
+          handleTxHash(
             txHash,
-            { transactionParams, categoryCode, contractEventObj },
+            { transactionEventObj, categoryCode, contractEventObj },
             reject
           )
 
           callback && callback(null, txHash)
 
-          waitForTransactionReceipt(txHash).then(receipt => {
+          return waitForTransactionReceipt(txHash).then(receipt => {
             handleTxReceipt(
               receipt,
-              { transactionParams, categoryCode, contractEventObj },
+              { transactionEventObj, categoryCode, contractEventObj },
               reject
             )
           })
@@ -200,7 +199,7 @@ function sendTransaction(
         .catch(async errorObj => {
           rejected = handleTxError(
             errorObj,
-            { transactionParams, categoryCode, contractEventObj },
+            { transactionEventObj, categoryCode, contractEventObj },
             reject
           )
           callback && callback(errorObj)
@@ -208,9 +207,11 @@ function sendTransaction(
     } else {
       txPromise
         .on('transactionHash', async txHash => {
-          confirmed = handleTxHash(
+          confirmed = true
+
+          handleTxHash(
             txHash,
-            { transactionParams, categoryCode, contractEventObj },
+            { transactionEventObj, categoryCode, contractEventObj },
             reject
           )
           callback && callback(null, txHash)
@@ -218,14 +219,16 @@ function sendTransaction(
         .on('receipt', async receipt => {
           handleTxReceipt(
             receipt,
-            { transactionParams, categoryCode, contractEventObj },
+            { transactionEventObj, categoryCode, contractEventObj },
             reject
           )
         })
         .on('error', async errorObj => {
-          rejected = handleTxError(
+          rejected = true
+
+          handleTxError(
             errorObj,
-            { transactionParams, categoryCode, contractEventObj },
+            { transactionEventObj, categoryCode, contractEventObj },
             reject
           )
           callback && callback(errorObj)
@@ -236,40 +239,34 @@ function sendTransaction(
 
 async function handleTxHash(txHash, meta, reject) {
   const nonce = await inferNonce().catch(reject)
-  const { transactionParams, categoryCode, contractEventObj } = meta
+  const { transactionEventObj, categoryCode, contractEventObj } = meta
 
-  onResult(transactionParams, nonce, categoryCode, contractEventObj, txHash)
-
-  return true // confirmed
+  onResult(transactionEventObj, nonce, categoryCode, contractEventObj, txHash)
 }
 
 async function handleTxReceipt(receipt, meta, reject) {
   const { transactionHash } = receipt
   const txObj = getTransactionObj(transactionHash)
   const nonce = await inferNonce().catch(reject)
-  const { transactionParams, categoryCode, contractEventObj } = meta
+  const { transactionEventObj, categoryCode, contractEventObj } = meta
 
-  handleEvent(
-    addContractEventObj(
-      {
-        eventCode: 'txConfirmedClient',
-        categoryCode,
-        transaction:
-          (txObj && txObj.transaction) ||
-          Object.assign({}, transactionParams, {
-            hash: transactionHash,
-            nonce
-          }),
-        wallet: {
-          provider: state.currentProvider,
-          address: state.accountAddress,
-          balance: state.accountBalance,
-          minimum: state.config.minimumBalance
-        }
-      },
-      contractEventObj
-    )
-  )
+  handleEvent({
+    eventCode: 'txConfirmedClient',
+    categoryCode,
+    transaction:
+      (txObj && txObj.transaction) ||
+      Object.assign({}, transactionEventObj, {
+        hash: transactionHash,
+        nonce
+      }),
+    contract: contractEventObj,
+    wallet: {
+      provider: state.currentProvider,
+      address: state.accountAddress,
+      balance: state.accountBalance,
+      minimum: state.config.minimumBalance
+    }
+  })
 
   updateState({
     transactionQueue: removeTransactionFromQueue(
@@ -288,30 +285,24 @@ async function handleTxError(error, meta, reject) {
   }
 
   const nonce = await inferNonce().catch(reject)
-  const { transactionParams, categoryCode, contractEventObj } = meta
+  const { transactionEventObj, categoryCode, contractEventObj } = meta
 
-  handleEvent(
-    addContractEventObj(
-      {
-        eventCode:
-          errorMsg === 'transaction underpriced'
-            ? 'txUnderpriced'
-            : 'txSendFail',
-        categoryCode,
-        transaction: Object.assign({}, transactionParams, {
-          nonce
-        }),
-        reason: 'User denied transaction signature',
-        wallet: {
-          provider: state.currentProvider,
-          address: state.accountAddress,
-          balance: state.accountBalance,
-          minimum: state.config.minimumBalance
-        }
-      },
-      contractEventObj
-    )
-  )
+  handleEvent({
+    eventCode:
+      errorMsg === 'transaction underpriced' ? 'txUnderpriced' : 'txSendFail',
+    categoryCode,
+    transaction: Object.assign({}, transactionEventObj, {
+      nonce
+    }),
+    contract: contractEventObj,
+    reason: 'User denied transaction signature',
+    wallet: {
+      provider: state.currentProvider,
+      address: state.accountAddress,
+      balance: state.accountBalance,
+      minimum: state.config.minimumBalance
+    }
+  })
 
   updateState({ transactionAwaitingApproval: false })
 
@@ -328,22 +319,15 @@ async function handleTxError(error, meta, reject) {
   return true // rejected
 }
 
-function addContractEventObj(eventObj, contractEventObj) {
-  if (contractEventObj) {
-    return Object.assign({}, eventObj, { contract: contractEventObj })
-  }
-  return eventObj
-}
-
 // On result handler
 function onResult(
-  transactionParams,
+  transactionEventObj,
   nonce,
   categoryCode,
   contractEventObj,
   hash
 ) {
-  const transaction = Object.assign({}, transactionParams, {
+  const transaction = Object.assign({}, transactionEventObj, {
     hash,
     nonce,
     startTime: Date.now(),
@@ -351,22 +335,18 @@ function onResult(
     inTxPool: false
   })
 
-  handleEvent(
-    addContractEventObj(
-      {
-        eventCode: 'txSent',
-        categoryCode,
-        transaction,
-        wallet: {
-          provider: state.currentProvider,
-          address: state.accountAddress,
-          balance: state.accountBalance,
-          minimum: state.config.minimumBalance
-        }
-      },
-      contractEventObj
-    )
-  )
+  handleEvent({
+    eventCode: 'txSent',
+    categoryCode,
+    transaction,
+    contract: contractEventObj,
+    wallet: {
+      provider: state.currentProvider,
+      address: state.accountAddress,
+      balance: state.accountBalance,
+      minimum: state.config.minimumBalance
+    }
+  })
 
   updateState({
     transactionQueue: addTransactionToQueue({
@@ -384,22 +364,18 @@ function onResult(
       !transactionObj.transaction.inTxPool &&
       state.socketConnection
     ) {
-      handleEvent(
-        addContractEventObj(
-          {
-            eventCode: 'txStall',
-            categoryCode,
-            transaction,
-            wallet: {
-              provider: state.currentProvider,
-              address: state.accountAddress,
-              balance: state.accountBalance,
-              minimum: state.config.minimumBalance
-            }
-          },
-          contractEventObj
-        )
-      )
+      handleEvent({
+        eventCode: 'txStall',
+        categoryCode,
+        transaction,
+        contract: contractEventObj,
+        wallet: {
+          provider: state.currentProvider,
+          address: state.accountAddress,
+          balance: state.accountBalance,
+          minimum: state.config.minimumBalance
+        }
+      })
     }
   }, timeouts.txStall)
 }


### PR DESCRIPTION
This PR introduces code that creates a `UUIDv4` for each transaction once it has been requested. This gives `Assist.js` more fine grained control over transaction notifications as it is no longer relying on the transaction hash as the unique identifier.

Closes #67 