### PR TITLE
Touch Events on mobile

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -76,7 +76,11 @@ function init(config) {
   getUserAgent()
 
   // Commit a cardinal sin and create an iframe (to isolate the CSS)
-  if (!state.iframe && !headlessMode) {
+  if (
+    !state.iframe &&
+    !headlessMode &&
+    (!state.mobileDevice || mobileBlocked)
+  ) {
     createIframe(document, styles)
   }
 


### PR DESCRIPTION
Added check to not render iframe if a user is on mobile and mobile isn't blocked so that touch events work correctly on mobile.

When we add full support for mobile we will need to implement a more thorough solution that will involve adjusting the z-index of the iFrame dynamically so as to not interfere with touch events on mobile.
