### PR TITLE
Fix/support truffle contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ var config = {
     darkMode: Boolean, // Set Assist UI to dark mode
     notificationsPosition: String, // Defines which corner transaction notifications will be positioned. Options: 'topLeft', 'topRight', 'bottomRight', 'bottomLeft'. ['bottomRight']
     css: String // Custom css string to overide Assist default styles
-  }
+  },
+  truffleContract: Boolean, // Set to true if contract object has been instantiated with truffle-contract [false]
 }
 ```
 

--- a/src/__tests__/js/init.test.js
+++ b/src/__tests__/js/init.test.js
@@ -59,7 +59,11 @@ test('Fails if we try to decorate without a web3 instance', () => {
 test('Does not delete any methods from the contract object when decorating', () => {
   const web3 = new Web3('ws://example.com')
   stateMock.state.web3Instance = web3
-  const assistWithWeb3 = da.init({ dappId: 'something', web3 })
+  stateMock.state.config = {}
+  const assistWithWeb3 = da.init({
+    dappId: 'something',
+    web3
+  })
   const contract = new web3.eth.Contract(
     abi,
     '0x0000000000000000000000000000000000000000'

--- a/src/js/helpers/web3.js
+++ b/src/js/helpers/web3.js
@@ -42,10 +42,14 @@ export const web3Functions = {
     switch (version) {
       case '0.2':
         return (contractMethod, parameters, txObject) =>
-          promisify(contractMethod.estimateGas)(...parameters, txObject)
+          state.config.truffleContract
+            ? contractMethod.estimateGas(...parameters, txObject)
+            : promisify(contractMethod.estimateGas)(...parameters, txObject)
       case '1.0':
         return (contractMethod, parameters, txObject) =>
-          contractMethod(...parameters).estimateGas(txObject)
+          state.config.truffleContract
+            ? contractMethod.estimateGas(...parameters, txObject)
+            : contractMethod(...parameters).estimateGas(txObject)
       default:
         return () => Promise.reject(errorObj)
     }

--- a/src/js/logic/send-transaction.js
+++ b/src/js/logic/send-transaction.js
@@ -124,7 +124,7 @@ function sendTransaction(
 
     let txPromise
 
-    if (state.legacyWeb3) {
+    if (state.legacyWeb3 || state.config.truffleContract) {
       if (contractEventObj) {
         txPromise = sendTransactionMethod(
           ...contractEventObj.parameters,
@@ -189,6 +189,20 @@ function sendTransaction(
           return waitForTransactionReceipt(hash).then(() => {
             onTxReceipt(transactionId, categoryCode)
           })
+        })
+        .catch(async errorObj => {
+          onTxError(transactionId, errorObj, categoryCode)
+          handleError({ resolve, reject, callback })(errorObj)
+        })
+    } else if (state.config.truffleContract) {
+      txPromise
+        .then(async hash => {
+          onTxHash(transactionId, hash, categoryCode)
+
+          const receipt = await waitForTransactionReceipt(hash)
+          onTxReceipt(transactionId, categoryCode)
+          resolve({ receipt })
+          callback && callback(null, receipt)
         })
         .catch(async errorObj => {
           onTxError(transactionId, errorObj, categoryCode)


### PR DESCRIPTION
This PR adds support for contracts that have been instantiated with [`truffle-contract`](https://github.com/trufflesuite/truffle/tree/develop/packages/truffle-contract). It involved a few changes as transactions are called in a version `0.2` of web3.js style, even if the dapp is using version `1.0` of web3.js. Also transactions are already wrapped in a promise by default so they don't need to be wrapped twice.