### PR TITLE
fix handling of txPool eventCode from server

### DIFF
--- a/src/js/helpers/events.js
+++ b/src/js/helpers/events.js
@@ -8,7 +8,7 @@ import { getItem } from './storage'
 export function handleEvent(eventObj, clickHandlers) {
   const { eventCode, categoryCode } = eventObj
   const serverEvent =
-    eventCode === 'txPool' ||
+    eventCode === 'txPending' ||
     eventCode === 'txConfirmed' ||
     eventCode === 'txFailed' ||
     eventCode === 'txSpeedUp' ||

--- a/src/js/helpers/websockets.js
+++ b/src/js/helpers/websockets.js
@@ -100,7 +100,7 @@ export function handleSocketMessage(msg) {
   }
 
   if (event && event.transaction) {
-    const { transaction, eventCode } = event
+    const { transaction } = event
     let txObj
 
     switch (transaction.status) {
@@ -111,7 +111,7 @@ export function handleSocketMessage(msg) {
         })
 
         handleEvent({
-          eventCode,
+          eventCode: 'txPending',
           categoryCode: 'activeTransaction',
           transaction: txObj.transaction,
           contract: txObj.contract,


### PR DESCRIPTION
Assist client uses `TxPending` to manage its internal state on pending notification, even though the server sends a `TxPool` eventCode. Since the client uses the `transaction.status` to determine if the transaction is `pending`, the client doesn't really care what eventCode the server sends.

This fix makes Assist internally consistent using `TxPending`.

NOTE: The server sends a `TxPool` eventCode because it checks both the pending and queued parts of the mempool. In the future, we may want the server to send `TxPending` and `TxQueued` eventCodes if the client UI, or transaction analytics, can use that differentiation.