### PR TITLE
txConfirmedClient uses same message as txConfirmed

### DIFF
--- a/src/js/views/content.js
+++ b/src/js/views/content.js
@@ -261,8 +261,6 @@ export const transactionMsgs = {
     'Please confirm your transaction to continue (hint: the transaction window may be behind your browser)',
   txConfirmed: ({ transaction }) =>
     `Your transaction ID: ${transaction.nonce} has succeeded`,
-  txConfirmedClient: ({ transaction }) =>
-    `Your transaction ID: ${transaction.nonce} has succeeded`,
   txSpeedUp: ({ transaction }) =>
     `Your transaction ID: ${transaction.nonce} has been sped up`,
   txCancel: ({ transaction }) =>

--- a/src/js/views/event-to-ui.js
+++ b/src/js/views/event-to-ui.js
@@ -163,6 +163,9 @@ function notificationsUI({
   inlineCustomMsgs,
   eventCode
 }) {
+  // treat txConfirmedClient as txConfirm
+  if (eventCode === 'txConfirmedClient') eventCode = 'txConfirmed'
+
   const { id, startTime } = transaction
   const type = eventCodeToType(eventCode)
   const timeStamp = formatTime(Date.now())


### PR DESCRIPTION
The `txConfirmedClient` eventCode is generated on the client to capture a tx confirmation from MetaMask when the server has not yet indicated such confirmation (server down, connection slow, etc.)

However, from a user and dapp developer perspective, there should be no difference between `txConfirmedClient` and `txConfirmed`. This change ensures there is only the single confirmation message, regardless of how that confirmation is first detected.