### PR TITLE
Contract decoration improvements

### DIFF
--- a/src/__tests__/js/contract/index.test.js
+++ b/src/__tests__/js/contract/index.test.js
@@ -61,25 +61,52 @@ multidepRequire.forEachVersion('web3', (version, Web3) => {
           afterEach(() => {
             if (name === 'truffle') state.config.truffleContract = false
           })
-          test.only(`it doesn't fail and returns the expected decorated contract`, () => {
+          test(`it doesn't fail and returns the expected decorated contract`, () => {
             const decoratedContract = assistInstance.Contract(contract)
 
-            // check that methods on truffle and web3v0.20 contracts retain their properties
-            if (name === 'truffle' || version.includes('0.20')) {
-              const methodName = name === 'truffle' ? 'subtract' : 'setOwner'
+            // check that methods on truffle contracts retain their properties
+            if (name === 'truffle') {
+              const methodName = 'subtract'
               const originalKeys = Object.keys(contract[methodName])
               const decoratedKeys = Object.keys(decoratedContract[methodName])
-              expect(new Set(originalKeys)).toEqual(new Set(decoratedKeys))
+              expect(new Set(decoratedKeys)).toEqual(new Set(originalKeys))
             }
 
-            // check that methods on non-truffle web3v1 contracts retain their properties
-            if (version.includes('1.0') && name !== 'truffle') {
+            // check that methods on web3 v0.20 contracts retain their properties
+            if (version.includes('0.20') && name !== 'truffle') {
               const methodName = 'setOwner'
-              const originalKeys = Object.keys(contract.methods[methodName])
-              const decoratedKeys = Object.keys(
-                decoratedContract.methods[methodName]
-              )
-              expect(new Set(originalKeys)).toEqual(new Set(decoratedKeys))
+              const originalKeys = Object.keys(contract[methodName])
+              const decoratedKeys = Object.keys(decoratedContract[methodName])
+              expect(new Set(decoratedKeys)).toEqual(new Set(originalKeys))
+
+              const overLoadedMethodName = 'approve'
+              const overLoadedMethodArgs = ['address', 'address,uint256']
+              overLoadedMethodArgs.forEach(args => {
+                const originalKeys = Object.keys(
+                  contract[overLoadedMethodName][args]
+                )
+                const decoratedKeys = Object.keys(
+                  decoratedContract[overLoadedMethodName][args]
+                )
+                expect(new Set(decoratedKeys)).toEqual(new Set(originalKeys))
+              })
+            }
+
+            // check that methods on web3 v1 contracts retain their properties
+            if (version.includes('1.0') && name !== 'truffle') {
+              const methodsToTest = [
+                'setOwner',
+                'start()',
+                'mint(uint256)',
+                'mint(address,uint256)'
+              ]
+              methodsToTest.forEach(methodName => {
+                const originalKeys = Object.keys(contract.methods[methodName])
+                const decoratedKeys = Object.keys(
+                  decoratedContract.methods[methodName]
+                )
+                expect(new Set(originalKeys)).toEqual(new Set(decoratedKeys))
+              })
             }
 
             if (decoratedContract.methods) {

--- a/src/__tests__/js/contract/index.test.js
+++ b/src/__tests__/js/contract/index.test.js
@@ -66,6 +66,16 @@ multidepRequire.forEachVersion('web3', (version, Web3) => {
             })
             const decoratedContract = assistInstance.Contract(contract)
 
+            // check that methods on truffle and 0.20 the object retain their keys
+            if (name === 'truffle' || version.includes('0.20')) {
+              const methodName = name === 'truffle' ? 'subtract' : 'setOwner'
+              const originalKeys = new Set(Object.keys(contract[methodName]))
+              const decoratedKeys = new Set(
+                Object.keys(decoratedContract[methodName])
+              )
+              expect(originalKeys).toEqual(decoratedKeys)
+            }
+
             if (decoratedContract.methods) {
               // test web3js v1.0.0-beta.X
               expect({

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -329,9 +329,9 @@ function init(config) {
               legacySend(method, name, args, argsLength)
 
             // Add any additional properties onto the method function
-            Object.entries(contractObj[name]).forEach(([k, v]) => {
-              if (!newContractObj[name][k]) {
-                newContractObj[name][k] = v
+            Object.entries(method).forEach(([k, v]) => {
+              if (!Object.keys(newContractObj[name][key]).includes(k)) {
+                newContractObj[name][key][k] = v
               }
             })
           })
@@ -368,6 +368,14 @@ function init(config) {
               constant
                 ? modernCall(method, name, args)
                 : modernSend(method, name, args)
+
+            // Add any additional properties onto the method function
+            Object.entries(method).forEach(([k, v]) => {
+              if (!Object.keys(methodsObj[name]).includes(k)) {
+                methodsObj[name][k] = v
+              }
+            })
+
             seenMethods.push(name)
           }
 
@@ -385,6 +393,13 @@ function init(config) {
             constant
               ? modernCall(overloadedMethod, name, args)
               : modernSend(overloadedMethod, name, args)
+
+          // Add any additional properties onto the method function
+          Object.entries(overloadedMethod).forEach(([k, v]) => {
+            if (!Object.keys(methodsObj[overloadedMethodKey]).includes(k)) {
+              methodsObj[overloadedMethodKey][k] = v
+            }
+          })
 
           return methodsObj
         }, {})

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -301,7 +301,12 @@ function init(config) {
         newContractObj[name].sendTransaction = (...args) =>
           legacySend(method, name, args, argsLength)
 
-        newContractObj[name].getData = contractObj[name].getData
+        // Add any additional properties onto the method function
+        Object.entries(contractObj[name]).forEach(([k, v]) => {
+          if (!newContractObj[name][k]) {
+            newContractObj[name][k] = v
+          }
+        })
 
         if (overloadedMethodKeys) {
           overloadedMethodKeys.forEach(key => {
@@ -323,7 +328,12 @@ function init(config) {
             newContractObj[name][key].sendTransaction = (...args) =>
               legacySend(method, name, args, argsLength)
 
-            newContractObj[name][key].getData = contractObj[name][key].getData
+            // Add any additional properties onto the method function
+            Object.entries(contractObj[name]).forEach(([k, v]) => {
+              if (!newContractObj[name][k]) {
+                newContractObj[name][k] = v
+              }
+            })
           })
         }
       } else {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -303,7 +303,7 @@ function init(config) {
 
         // Add any additional properties onto the method function
         Object.entries(contractObj[name]).forEach(([k, v]) => {
-          if (!newContractObj[name][k]) {
+          if (!Object.keys(newContractObj[name]).includes(k)) {
             newContractObj[name][k] = v
           }
         })


### PR DESCRIPTION
Closes #202 
- Fixes issue where contract method properties weren't all being defined (eg `estimateGas`)
- Add tests to ensure contract method properties are being defined on the decoratedContract