### PR TITLE
coerce network id type to Number in getNetworkID and remove coercion …

### DIFF
--- a/src/js/helpers/utilities.js
+++ b/src/js/helpers/utilities.js
@@ -196,7 +196,7 @@ export function eventCodeToStep(eventCode) {
 }
 
 export function networkName(id) {
-  switch (Number(id)) {
+  switch (id) {
     case 1:
       return 'main'
     case 3:

--- a/src/js/helpers/web3.js
+++ b/src/js/helpers/web3.js
@@ -159,7 +159,9 @@ export function checkForWallet() {
 
 export function getNetworkId() {
   const version = state.web3Version && state.web3Version.slice(0, 3)
-  return web3Functions.networkId(version)()
+  return web3Functions
+    .networkId(version)()
+    .then(id => Number(id))
 }
 
 export function getTransactionParams(

--- a/src/js/logic/user.js
+++ b/src/js/logic/user.js
@@ -256,8 +256,7 @@ function checkAccountAccess() {
 export function checkNetwork() {
   return new Promise(async resolve => {
     const networkId = await getNetworkId().catch(handleWeb3Error)
-    const correctNetwork =
-      Number(networkId) === (Number(state.config.networkId) || 1)
+    const correctNetwork = networkId === (state.config.networkId || 1)
 
     updateState({
       correctNetwork,

--- a/src/js/views/content.js
+++ b/src/js/views/content.js
@@ -207,7 +207,7 @@ export function onboardWarningMsg(type) {
         ${state.config.minimumBalance / 1000000000000000000} ${capitalize(
         networkName(state.userCurrentNetworkId)
       )} ${
-        state.userCurrentNetworkId === '1' ? 'Ethereum' : 'Test'
+        state.userCurrentNetworkId === 1 ? 'Ethereum' : 'Test'
       } Network Ether (ETH).`
     default:
       return undefined


### PR DESCRIPTION
Closes #156

- Coerce value that is returned from `getNetworkId` to Number as different versions of `web3` return different types
- Remove coercion spread throughout codebase

**NOTE: Merge after PR that addresses #230 has been created and merged as this PR assumes that networkId value in config has been validated as a Number type.**
