### PR TITLE
Fix iframe error

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ The function that is defined on the `handleNotificationEvent` property of the co
     parameters: Array, // the parameters the method was called with
   },
   inlineCustomMsgs: Object | Boolean, // the inline custom messages passed to the transaction
+  reason: String, // reason for error type notifications
   transaction: {
     id: String, // internal unique id for the transaction
     from: String, // the address the transaction was sent from

--- a/src/js/helpers/events.js
+++ b/src/js/helpers/events.js
@@ -44,7 +44,7 @@ export function handleEvent(eventObj, clickHandlers) {
         ? handleNotificationEvent(eventObj)
         : true
 
-    if (!showNotification) {
+    if (!showNotification && !headlessMode) {
       removeUnwantedNotifications(eventCode, transaction.id)
     }
   }


### PR DESCRIPTION
Closes #309 

Also added missing `reason` property in the documentation for `handleNotificationEvent` that occurs for error type notification events.