### PR TITLE
Add `transaction.to` field after it is available

### DIFF
--- a/src/js/logic/send-transaction.js
+++ b/src/js/logic/send-transaction.js
@@ -161,6 +161,9 @@ export function sendTransaction({
       txPromise = sendMethod(txOptions)
     }
 
+    // to field doesn't get populated until after the transaction has been initiated
+    transactionEventObj.to = txOptions.to
+
     handleEvent({
       eventCode: 'txRequest',
       categoryCode,


### PR DESCRIPTION
Closes #332 

The `to` field isn't available until after the transaction has been initiated. This PR adds the `to` property to the `transactionObject` once it is available.