### PR TITLE
Improve error handling for transactions

### DIFF
--- a/src/js/helpers/utilities.js
+++ b/src/js/helpers/utilities.js
@@ -132,8 +132,24 @@ export function assistLog(log) {
 }
 
 export function extractMessageFromError(message) {
-  const str = message.split('"message":')[1]
-  return str.split('"')[1]
+  if (message.includes('User denied transaction signature')) {
+    return {
+      eventCode: 'txSendFail',
+      errorMsg: 'User denied transaction signature'
+    }
+  }
+
+  if (message.includes('transaction underpriced')) {
+    return {
+      eventCode: 'txUnderpriced',
+      errorMsg: 'Transaction is under priced'
+    }
+  }
+
+  return {
+    eventCode: 'txError',
+    errorMsg: message
+  }
 }
 
 export function eventCodeToType(eventCode) {
@@ -152,6 +168,7 @@ export function eventCodeToType(eventCode) {
     case 'txRepeat':
     case 'txAwaitingApproval':
     case 'txConfirmReminder':
+    case 'txUnderpriced':
     case 'error':
       return 'failed'
     case 'txConfirmed':

--- a/src/js/logic/send-transaction.js
+++ b/src/js/logic/send-transaction.js
@@ -357,32 +357,33 @@ async function onTxReceipt(id, categoryCode, receipt) {
 }
 
 function onTxError(id, error, categoryCode) {
-  const { message } = error
-  let errorMsg
-  try {
-    errorMsg = extractMessageFromError(message)
-  } catch (error) {
-    errorMsg = 'User denied transaction signature'
+  const { errorMsg, eventCode } = extractMessageFromError(error.message)
+
+  let txObj = getTxObjFromQueue(id)
+
+  if (
+    txObj &&
+    (txObj.transaction.status !== 'confirmed' ||
+      txObj.transaction.status !== 'completed')
+  ) {
+    txObj = updateTransactionInQueue(id, { status: 'error' })
+
+    handleEvent({
+      eventCode,
+      categoryCode,
+      transaction: txObj.transaction,
+      contract: txObj.contract,
+      inlineCustomMsgs: txObj.inlineCustomMsgs,
+      clickHandlers: txObj.clickHandlers,
+      reason: errorMsg,
+      wallet: {
+        provider: state.currentProvider,
+        address: state.accountAddress,
+        balance: state.accountBalance,
+        minimum: state.config.minimumBalance
+      }
+    })
   }
-
-  const txObj = updateTransactionInQueue(id, { status: 'rejected' })
-
-  handleEvent({
-    eventCode:
-      errorMsg === 'transaction underpriced' ? 'txUnderpriced' : 'txSendFail',
-    categoryCode,
-    transaction: txObj.transaction,
-    contract: txObj.contract,
-    inlineCustomMsgs: txObj.inlineCustomMsgs,
-    clickHandlers: txObj.clickHandlers,
-    reason: errorMsg,
-    wallet: {
-      provider: state.currentProvider,
-      address: state.accountAddress,
-      balance: state.accountBalance,
-      minimum: state.config.minimumBalance
-    }
-  })
 
   removeTransactionFromQueue(id)
 }

--- a/src/js/views/content.js
+++ b/src/js/views/content.js
@@ -377,5 +377,7 @@ export const transactionMsgs = {
   txSpeedUp: ({ transaction }) =>
     `Your transaction ID: ${transaction.nonce} has been sped up`,
   txCancel: ({ transaction }) =>
-    `Your transaction ID: ${transaction.nonce} is being canceled`
+    `Your transaction ID: ${transaction.nonce} is being canceled`,
+  txUnderpriced: () =>
+    'The gas price for your transaction is too low, try again with a higher gas price'
 }

--- a/src/js/views/event-to-ui.js
+++ b/src/js/views/event-to-ui.js
@@ -77,7 +77,8 @@ const eventToUI = {
     txStall: notificationsUI,
     txFailed: notificationsUI,
     txSpeedUp: notificationsUI,
-    txCancel: notificationsUI
+    txCancel: notificationsUI,
+    txUnderpriced: notificationsUI
   },
   activeContract: {
     txAwaitingApproval: notificationsUI,
@@ -91,7 +92,8 @@ const eventToUI = {
     txStall: notificationsUI,
     txFailed: notificationsUI,
     txSpeedUp: notificationsUI,
-    txCancel: notificationsUI
+    txCancel: notificationsUI,
+    txUnderpriced: notificationsUI
   },
   userInitiatedNotify: {
     success: notificationsUI,


### PR DESCRIPTION
This PR partly addresses issue #359 by not showing a notification if the error comes after transaction has already received a confirmed event. This will stop the incorrect notification being shown in some cases.

A notification is also now only shown when Assist knows exactly what the error is. Currently Assist is aware of two errors:

- Transaction was rejected by the user
- Transaction was sent with too low a gas price

Unfortunately due to limitations with extensions, web3 and ethers don't return the entire error object that is returned by the provider which includes an error code that could be used to map to an error message.

Any errors that occur that don't match what Assist is currently aware about will be logged to the server for now without feedback being given to the user. We will observe those logs and start to build a list of error messages and their strings so that we can eventually add the correct notifications to Assist to inform users. We can then close the issue completely.