### PR TITLE
Fix errors when there is no message property

### DIFF
--- a/src/js/helpers/utilities.js
+++ b/src/js/helpers/utilities.js
@@ -132,6 +132,13 @@ export function assistLog(log) {
 }
 
 export function extractMessageFromError(message) {
+  if (!message) {
+    return {
+      eventCode: 'txError',
+      errorMsg: 'Unknown error'
+    }
+  }
+
   if (message.includes('User denied transaction signature')) {
     return {
       eventCode: 'txSendFail',

--- a/src/js/helpers/utilities.js
+++ b/src/js/helpers/utilities.js
@@ -135,7 +135,7 @@ export function extractMessageFromError(message) {
   if (!message) {
     return {
       eventCode: 'txError',
-      errorMsg: 'Unknown error'
+      errorMsg: undefined
     }
   }
 

--- a/src/js/logic/send-transaction.js
+++ b/src/js/logic/send-transaction.js
@@ -404,7 +404,7 @@ function onTxError(id, error, categoryCode) {
       contract: txObj.contract,
       inlineCustomMsgs: txObj.inlineCustomMsgs,
       clickHandlers: txObj.clickHandlers,
-      reason: errorMsg,
+      reason: errorMsg || JSON.stringify(error),
       wallet: {
         provider: state.currentProvider,
         address: state.accountAddress,


### PR DESCRIPTION
This PR closes #370 

We now `JSON.stringify` and log the entire error if there is no `message` property to avoid internal errors and to hopefully be able to observe on our backend what is actually causing the error when sending a transaction.