### PR TITLE
Make browser check optional in onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ var config = {
   mobileBlocked: Boolean, // Defines if the Dapp works on mobile [false]
   minimumBalance: String, // Defines the minimum balance in Wei that a user needs to have to use the Dapp [0]
   headlessMode: Boolean, // Turn off Assist UI, but still retain analytics collection [false]
+  browserCheck: Boolean, // Check if the user is on a browser that supports extension wallets during onboarding [true]
   messages: {
     // See custom transaction messages section below for more details
     txRequest: Function, // Transaction request has been initiated and is awaiting user approval

--- a/src/js/helpers/validation.js
+++ b/src/js/helpers/validation.js
@@ -25,6 +25,7 @@ export function validateConfig(config) {
         mobileBlocked: ow.optional.boolean,
         minimumBalance: ow.optional.string,
         headlessMode: ow.optional.boolean,
+        browserCheck: ow.optional.boolean,
         messages: ow.optional.object.exactShape({
           txRequest: ow.optional.function,
           txSent: ow.optional.function,

--- a/src/js/logic/user.js
+++ b/src/js/logic/user.js
@@ -69,7 +69,11 @@ export function prepareForTransaction(categoryCode, originalResolve) {
     }
 
     if (getItem('_assist_newUser') === 'true') {
-      if (!state.validBrowser && !state.mobileDevice) {
+      if (
+        !state.validBrowser &&
+        !state.mobileDevice &&
+        state.config.browserCheck !== false
+      ) {
         handleEvent(
           {
             eventCode: 'browserFail',


### PR DESCRIPTION
This PR will allow a dev to add `browserCheck: false` to the Assist config to bypass internal checks during onboarding that usually ensure that the user is on a browser that is compatible with extensions.

Closes #374 