### PR TITLE
MetaMask Error Object

### DIFF
--- a/src/js/helpers/utilities.js
+++ b/src/js/helpers/utilities.js
@@ -131,13 +131,15 @@ export function assistLog(log) {
   console.log('Assist:', log) // eslint-disable-line no-console
 }
 
-export function extractMessageFromError(message) {
-  if (!message) {
+export function extractMessageFromError(error) {
+  if (!error.stack || !error.message) {
     return {
       eventCode: 'txError',
       errorMsg: undefined
     }
   }
+
+  const message = error.stack || error.message
 
   if (message.includes('User denied transaction signature')) {
     return {
@@ -177,6 +179,7 @@ export function eventCodeToType(eventCode) {
     case 'txAwaitingApproval':
     case 'txConfirmReminder':
     case 'txUnderpriced':
+    case 'txError':
     case 'error':
       return 'failed'
     case 'txConfirmed':

--- a/src/js/logic/send-transaction.js
+++ b/src/js/logic/send-transaction.js
@@ -386,7 +386,7 @@ async function onTxReceipt(id, categoryCode, receipt) {
 }
 
 function onTxError(id, error, categoryCode) {
-  const { errorMsg, eventCode } = extractMessageFromError(error.message)
+  const { errorMsg, eventCode } = extractMessageFromError(error)
 
   let txObj = getTxObjFromQueue(id)
 

--- a/src/js/views/content.js
+++ b/src/js/views/content.js
@@ -381,5 +381,7 @@ export const transactionMsgs = {
   txCancel: ({ transaction }) =>
     `Your transaction ID: ${transaction.nonce} is being canceled`,
   txUnderpriced: () =>
-    'The gas price for your transaction is too low, try again with a higher gas price'
+    'The gas price for your transaction is too low, try again with a higher gas price',
+  txError: () =>
+    'An unknown error has occurred with your transaction, please try again'
 }

--- a/src/js/views/event-to-ui.js
+++ b/src/js/views/event-to-ui.js
@@ -79,7 +79,8 @@ const eventToUI = {
     txFailed: notificationsUI,
     txSpeedUp: notificationsUI,
     txCancel: notificationsUI,
-    txUnderpriced: notificationsUI
+    txUnderpriced: notificationsUI,
+    txError: notificationsUI
   },
   activeContract: {
     txAwaitingApproval: notificationsUI,
@@ -95,7 +96,8 @@ const eventToUI = {
     txFailed: notificationsUI,
     txSpeedUp: notificationsUI,
     txCancel: notificationsUI,
-    txUnderpriced: notificationsUI
+    txUnderpriced: notificationsUI,
+    txError: notificationsUI
   },
   userInitiatedNotify: {
     success: notificationsUI,


### PR DESCRIPTION
This PR: 

- Handles the new structure of the error returned from MetaMask when a transaction error occurs. - Add a transaction notification that informs the user an unknown error has occurred for when there is no `stack` or `message` parameter on the error object.

Closes #377 